### PR TITLE
Setup ESLint and server tests with Mocha + Chai

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -20,7 +20,7 @@ export default class Dinder extends Component {
 
     var apiRoot = config.apiRoot;
 
-    if (process.NODE_ENV !== 'production') {
+    if (process.env.NODE_ENV !== 'production') {
       apiRoot = Platform.OS === 'android'
               ? config.androidLocalRoot
               : config.iosLocalRoot;

--- a/config.js
+++ b/config.js
@@ -1,5 +1,5 @@
 var secrets;
-if (process.NODE_ENV !== 'production') {
+if (process.env.NODE_ENV !== 'production') {
   secrets = require('./secrets.json');
 }
 

--- a/package.json
+++ b/package.json
@@ -5,9 +5,14 @@
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "server": "nodemon -w server server/index.js",
+    "test": "mocha spec/**",
+    "test:es6": "mocha --require babel-core/register spec/**",
     "lint": "eslint ./"
   },
   "dependencies": {
+    "babel-cli": "^6.14.0",
+    "babel-core": "^6.14.0",
+    "babel-preset-es2015": "^6.14.0",
     "body-parser": "^1.15.2",
     "express": "^4.14.0",
     "react": "15.3.2",
@@ -15,5 +20,9 @@
     "react-native-button": "^1.7.0",
     "request": "^2.75.0",
     "request-promise": "^4.1.1"
+  },
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "mocha": "^3.0.2"
   }
 }

--- a/spec/server/basic.js
+++ b/spec/server/basic.js
@@ -13,7 +13,7 @@ describe('the API server', function () {
   it('should respond to GET requests', function (done) {
     request(apiRoot + ':' + config.port + '/', function (err, res, body) {
       if (err) {
-        done(err)
+        done(err);
       }
       expect(JSON.parse(body)).to.be.an('object');
       done();

--- a/spec/server/basic.js
+++ b/spec/server/basic.js
@@ -1,0 +1,22 @@
+var request = require('request');
+var expect = require('chai').expect;
+var config = require('../../config.js');
+
+var apiRoot;
+
+describe('the API server', function () {
+  before(function () {
+    apiRoot = process.env.NODE_ENV !== 'production'
+                ? 'http://localhost'
+                : config.apiRoot;
+  });
+  it('should respond to GET requests', function (done) {
+    request(apiRoot + ':' + config.port + '/', function (err, res, body) {
+      if (err) {
+        done(err)
+      }
+      expect(JSON.parse(body)).to.be.an('object');
+      done();
+    });
+  });
+});

--- a/spec/server/basic.js
+++ b/spec/server/basic.js
@@ -7,8 +7,8 @@ var apiRoot;
 describe('the API server', function () {
   before(function () {
     apiRoot = process.env.NODE_ENV !== 'production'
-                ? 'http://localhost'
-                : config.apiRoot;
+            ? 'http://localhost'
+            : config.apiRoot;
   });
   it('should respond to GET requests', function (done) {
     request(apiRoot + ':' + config.port + '/', function (err, res, body) {


### PR DESCRIPTION
also corrects 'process.NODE_ENV' to 'process.env.NODE_ENV' in app/index.js and config.js